### PR TITLE
arm64 architecture seems to not be supported when running during jenk…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,4 +2,4 @@ FROM public.ecr.aws/n8h1l8f0/amzn-linux-2/cargo-lambda:1.0.1
 
 # Build lambda rust app
 COPY ./ ./
-RUN cargo lambda build --release --arm64
+RUN cargo lambda build --release


### PR DESCRIPTION
arm64 architecture seems to not be supported when running during jenkins pipeline